### PR TITLE
Fix event detail argument structure

### DIFF
--- a/src/window-manager.js
+++ b/src/window-manager.js
@@ -105,7 +105,7 @@ export default class WindowManager {
       };
 
       if (supportsCustomEvents) {
-        event = new CustomEvent(EVENT_NAME, detail);
+        event = new CustomEvent(EVENT_NAME, { detail });
       } else {
         event = document.createEvent('CustomEvent');
         event.initCustomEvent(EVENT_NAME, false, false, detail);


### PR DESCRIPTION
I noticed `e.detail.breakpoint` was declaring detail null. After some poking around I found that the detail object key was not being included when passed as an argument to the CustomEvent function, so `detail` would always be undefined. I'm sure it was just an oversight!

Update: only `new CustomEvent` needs the `detail` key, `initCustomEvent` needs just the data within the detail object.